### PR TITLE
Update release notes for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Fundraising Store 1.x:
 ```js
 {
     "require": {
-        "wmde/fundraising-store": "~1.0"
+        "wmde/fundraising-store": "^1.0.0"
     }
 }
 ```
@@ -44,11 +44,9 @@ run style checks use `composer cs`.
 
 ## Release notes
 
-### Version 0.2 (2015-07-10)
+### Version 1.0 (2015-08-21)
 
 * Added CLI configuration for Doctrine ORM shell commands
-
-* Factored out EntityManager configuration into `Store\EntityManagerProvider`
 
 ### Version 0.1 (2015-07-10)
 


### PR DESCRIPTION
We still need to make a release of the post 0.1 code, so we can remove the `@dev` stability modifier flags in the `require` sections of the fundraising applications.

Changing `0.2` to `1.0` as making a `1.0` rel seems more appropriate than a `0.2` one (as per http://semver.org/).

Before making the `1.0.0` tag, the release notes should probably be updated to reflect which relevant changes where made to the users of the package. Though then again, we are already using these changes due to working against master, so this is certainly less important than usually.