### PR TITLE
Add request type and status constants

### DIFF
--- a/src/Entities/Request.php
+++ b/src/Entities/Request.php
@@ -2,7 +2,6 @@
 
 namespace WMDE\Fundraising\Entities;
 
-use ContactRequest;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -260,6 +259,16 @@ class Request {
 	 */
 	private $id;
 
+	const STATUS_CONFIRMED = 1;
+	const STATUS_NEUTRAL = 0;
+	const STATUS_DELETED = -1;
+	const STATUS_MODERATION = -2;
+	const STATUS_ABORTED = -4;
+	const STATUS_CANCELED = -8;
+
+	const TYPE_MEMBERSHIP = 'membership';
+	const TYPE_SUBSCRIPTION = 'subscription';
+	const TYPE_OTHER = 'other';
 
 	/**
 	 * Set donationId
@@ -987,7 +996,7 @@ class Request {
 	}
 
 	public function isUnconfirmed() {
-		return $this->getStatus() === ContactRequest::STATUS_NEUTRAL;
+		return $this->getStatus() === self::STATUS_NEUTRAL;
 	}
 
 	public function log( $message ) {


### PR DESCRIPTION
`Request` entity has been referring to constant from the evil `ContactRequest` from the "frontend" application.
Those status and type constants are also used in some frontend's classes, so I think it makes sense to move them all here.