### PR TITLE
get rid of PHP 5.4 travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.6
   - 7
 


### PR DESCRIPTION
servers updated to PHP 5.6