### PR TITLE
Fix Request date defaults

### DIFF
--- a/src/Entities/Request.php
+++ b/src/Entities/Request.php
@@ -21,7 +21,7 @@ class Request {
 	/**
 	 * @var \DateTime
 	 *
-	 * @ORM\Column(name="timestamp", type="datetime", nullable=false)
+	 * @ORM\Column(name="timestamp", type="datetime", nullable=true)
 	 */
 	private $timestamp;
 
@@ -269,12 +269,7 @@ class Request {
 	const TYPE_MEMBERSHIP = 'membership';
 	const TYPE_SUBSCRIPTION = 'subscription';
 	const TYPE_OTHER = 'other';
-
-	public function __construct() {
-		$this->setTimestamp( new \DateTime( '1970-01-01 00:00:00' ) );
-	}
-
-
+	
 	/**
 	 * Set donationId
 	 *

--- a/src/Entities/Request.php
+++ b/src/Entities/Request.php
@@ -21,9 +21,9 @@ class Request {
 	/**
 	 * @var \DateTime
 	 *
-	 * @ORM\Column(name="timestamp", type="datetime", options={"default":"1970-01-01 00:00:00"}, nullable=false)
+	 * @ORM\Column(name="timestamp", type="datetime", nullable=false)
 	 */
-	private $timestamp = '1970-01-01 00:00:00';
+	private $timestamp;
 
 	/**
 	 * @var string
@@ -105,9 +105,9 @@ class Request {
 	/**
 	 * @var \DateTime
 	 *
-	 * @ORM\Column(name="dob", type="date", options={"default":"0000-00-00"}, nullable=false)
+	 * @ORM\Column(name="dob", type="date", nullable=true)
 	 */
-	private $dob = '0000-00-00';
+	private $dob;
 
 	/**
 	 * @var string
@@ -269,6 +269,11 @@ class Request {
 	const TYPE_MEMBERSHIP = 'membership';
 	const TYPE_SUBSCRIPTION = 'subscription';
 	const TYPE_OTHER = 'other';
+
+	public function __construct() {
+		$this->setTimestamp( new \DateTime( '1970-01-01 00:00:00' ) );
+	}
+
 
 	/**
 	 * Set donationId

--- a/tests/integration/RequestInsertionTest.php
+++ b/tests/integration/RequestInsertionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace WMDE\Fundraising\Store\Tests;
+
+use WMDE\Fundraising\Entities\Request;
+
+class RequestInsertionTest extends \PHPUnit_Framework_TestCase {
+
+	public function testNewRequestCanBeInserted() {
+		$entityManager = TestEnvironment::newDefault()->getFactory()->getEntityManager();
+		$request = new Request();
+		$entityManager->persist( $request );
+		$entityManager->flush();
+		$count = $entityManager->createQueryBuilder()
+			->select( 'COUNT(r.id)' )
+			->from( Request::class, 'r')
+			->getQuery()
+			->getSingleScalarResult();
+		$this->assertEquals( 1, $count );
+	}
+}

--- a/tests/integration/RequestInsertionTest.php
+++ b/tests/integration/RequestInsertionTest.php
@@ -9,14 +9,13 @@ class RequestInsertionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNewRequestCanBeInserted() {
 		$entityManager = TestEnvironment::newDefault()->getFactory()->getEntityManager();
-		$request = new Request();
-		$entityManager->persist( $request );
+		$entityManager->persist( new Request() );
 		$entityManager->flush();
 		$count = $entityManager->createQueryBuilder()
 			->select( 'COUNT(r.id)' )
-			->from( Request::class, 'r')
+			->from( Request::class, 'r' )
 			->getQuery()
 			->getSingleScalarResult();
-		$this->assertEquals( 1, $count );
+		$this->assertEquals( 1, $count ); // Can't use assertSame because a string is returned
 	}
 }


### PR DESCRIPTION
When inserting a `Request` entity with the `EntityManager`, the insertion failed with "Call to a member function format() on string" because of the string defaults for the date fields.

Now the DOB is nullable and the timestamp has the old default value of 1970-01-01 0:00:00