### PR TITLE
Fix Doctrine console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ build/
 .floo
 .flooignore
 
-config.ini
+local-db-config.php

--- a/cli-config.php
+++ b/cli-config.php
@@ -4,7 +4,13 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
 use WMDE\Fundraising\Store\Factory;
 
-require_once( '../../local-db-config.php' );
+// Load config for both dependency and standalone use case
+if ( file_exists( __DIR__ . '/../../local-db-config.php' ) ) {
+	require_once( __DIR__ . '/../../local-db-config.php' );
+}
+else {
+	require_once( __DIR__ . '/local-db-config.php' );
+}
 
 $factory = new Factory( DriverManager::getConnection( [
 	'driver' => 'pdo_mysql',

--- a/cli-config.php
+++ b/cli-config.php
@@ -7,8 +7,7 @@ use WMDE\Fundraising\Store\Factory;
 // Load config for both dependency and standalone use case
 if ( file_exists( __DIR__ . '/../../local-db-config.php' ) ) {
 	require_once( __DIR__ . '/../../local-db-config.php' );
-}
-else {
+} else {
 	require_once( __DIR__ . '/local-db-config.php' );
 }
 


### PR DESCRIPTION
When working on the "standalone" version of the library (for creating new entities, etc), the Doctrine command line utility in `vendor/bin/` failed because its configuration in `cli-config.php` tried to include a database configuration outside of the FundraisingStore directory. 

Changed the config name in .gitignore which still contained an ini file instead of the php file.