### PR TITLE
Remove dev-master alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,6 @@
 			"WMDE\\Fundraising\\": "src/"
 		}
 	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "2.0.x-dev"
-		}
-	},
 	"scripts": {
 		"test": [
 			"composer validate --no-interaction",


### PR DESCRIPTION
The branch 2.0.x does not exist anymore and we decided to develop the new
version in master instead of the 2.x branch.