### PR TITLE
Remove GUID from Membership

### DIFF
--- a/src/Entities/Membership.php
+++ b/src/Entities/Membership.php
@@ -237,13 +237,6 @@ class Membership {
 	private $data;
 
 	/**
-	 * @var string
-	 *
-	 * @ORM\Column(name="guid", type="blob", length=16, nullable=true)
-	 */
-	private $guid;
-
-	/**
 	 * @var integer
 	 *
 	 * @ORM\Column(name="id", type="integer")


### PR DESCRIPTION
This field was used for the subscription entity. The accessor functions
were already removed, so this is just a small cleanup.