### PR TITLE
Make Donation's and Membership's creation timestamps non-nullable

### DIFF
--- a/src/Entities/Donation.php
+++ b/src/Entities/Donation.php
@@ -128,7 +128,7 @@ class Donation {
 	 * @var \DateTime
 	 *
 	 * @Gedmo\Timestampable(on="create")
-	 * @ORM\Column(name="dt_new", type="datetime", nullable=true)
+	 * @ORM\Column(name="dt_new", type="datetime")
 	 */
 	private $dtNew;
 

--- a/src/Entities/Membership.php
+++ b/src/Entities/Membership.php
@@ -22,8 +22,9 @@ class Membership {
 
 	/**
 	 * @var \DateTime
+	 *
 	 * @Gedmo\Timestampable(on="create")
-	 * @ORM\Column(name="timestamp", type="datetime", nullable=true)
+	 * @ORM\Column(name="timestamp", type="datetime")
 	 */
 	private $timestamp;
 


### PR DESCRIPTION
Having creation timestamps [set automatically](https://github.com/wmde/FundraisingStore/pull/43) means those fields should no longer be nullable.
Same as already done in [Subscription's entity case](https://github.com/wmde/FundraisingStore/blob/master/src/Entities/Subscription.php#L76)