### PR TITLE
Added needsModeration and isCancelled to MembershipApplication

### DIFF
--- a/src/Entities/MembershipApplication.php
+++ b/src/Entities/MembershipApplication.php
@@ -901,8 +901,25 @@ class MembershipApplication {
 		return $this->data;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function isUnconfirmed() {
-		return $this->getStatus() === self::STATUS_NEUTRAL;
+		return $this->status === self::STATUS_NEUTRAL;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function needsModeration() {
+		return $this->status < 0 && abs( $this->status ) & abs( self::STATUS_MODERATION );
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isCancelled() {
+		return $this->status < 0 && abs( $this->status ) & abs( self::STATUS_CANCELED );
 	}
 
 	public function log( $message ) {

--- a/tests/unit/MembershipApplicationTest.php
+++ b/tests/unit/MembershipApplicationTest.php
@@ -127,4 +127,48 @@ class MembershipApplicationTest extends \PHPUnit_Framework_TestCase {
 		$this->assertNotNull( MembershipApplication::STATUS_NEUTRAL );
 	}
 
+	public function testGivenModerationStatus_needsModerationReturnsTrue() {
+		$application = new MembershipApplication();
+		$application->setStatus( MembershipApplication::STATUS_MODERATION );
+
+		$this->assertTrue( $application->needsModeration() );
+	}
+
+	public function testGivenDefaultStatus_needsModerationReturnsFalse() {
+		$application = new MembershipApplication();
+
+		$this->assertFalse( $application->needsModeration() );
+	}
+
+	public function testGivenModerationAndCancelledStatus_needsModerationReturnsTrue() {
+		$application = new MembershipApplication();
+		$application->setStatus(
+			MembershipApplication::STATUS_MODERATION + MembershipApplication::STATUS_CANCELED
+		);
+
+		$this->assertTrue( $application->needsModeration() );
+	}
+
+	public function testGivenCancelledStatus_isCancelledReturnsTrue() {
+		$application = new MembershipApplication();
+		$application->setStatus( MembershipApplication::STATUS_CANCELED );
+
+		$this->assertTrue( $application->isCancelled() );
+	}
+
+	public function testGivenDefaultStatus_isCancelledReturnsFalse() {
+		$application = new MembershipApplication();
+
+		$this->assertFalse( $application->isCancelled() );
+	}
+
+	public function testGivenModerationAndCancelledStatus_isCancelledReturnsTrue() {
+		$application = new MembershipApplication();
+		$application->setStatus(
+			MembershipApplication::STATUS_MODERATION + MembershipApplication::STATUS_CANCELED
+		);
+
+		$this->assertTrue( $application->isCancelled() );
+	}
+
 }


### PR DESCRIPTION
Note: `Backend_Ajax_MemberController::hasStatus` in the backend app is broken as far as I can tell. If you don't abs the status field as well, and pass in `self::STATUS_CANCELED`, it should fail