### PR TITLE
Truncate string fields that are too long

### DIFF
--- a/src/Entities/Donation.php
+++ b/src/Entities/Donation.php
@@ -24,6 +24,8 @@ class Donation {
 	const STATUS_MODERATION = 'P';
 	const STATUS_CANCELLED = 'D';
 
+	const MAX_DATA_FIELD_LENGTH = 2048;
+
 	/**
 	 * @var integer
 	 *
@@ -668,7 +670,11 @@ class Donation {
 	 * @param array $data
 	 */
 	public function encodeAndSetData( array $data ) {
-		$this->data = base64_encode( serialize( $data ) );
+		$this->data = base64_encode(
+			serialize(
+				$this->truncateInsanelyLongFields( $data )
+			)
+		);
 	}
 
 	/**
@@ -722,6 +728,20 @@ class Donation {
 		$dataObject = $this->getDataObject();
 		$modificationFunction( $dataObject );
 		$this->setDataObject( $dataObject );
+	}
+
+	/**
+	 * @param array $data
+	 * @return array
+	 */
+	private function truncateInsanelyLongFields( array $data ) {
+		foreach ( array_keys( $data ) as $key ) {
+			if ( is_string( $data[$key] ) ) {
+				$data[$key] = substr( $data[$key], 0, self::MAX_DATA_FIELD_LENGTH );
+			}
+		}
+
+		return $data;
 	}
 
 }

--- a/src/Entities/MembershipApplication.php
+++ b/src/Entities/MembershipApplication.php
@@ -21,6 +21,8 @@ class MembershipApplication {
 	const STATUS_ABORTED = -4;
 	const STATUS_CANCELED = -8;
 
+	const MAX_DATA_FIELD_LENGTH = 2048;
+
 	/**
 	 * @var integer
 	 *
@@ -949,7 +951,11 @@ class MembershipApplication {
 	 * @param array $data
 	 */
 	public function encodeAndSetData( array $dataArray ) {
-		$this->data = base64_encode( serialize( $dataArray ) );
+		$this->data = base64_encode(
+			serialize(
+				$this->truncateInsanelyLongFields( $dataArray )
+			)
+		);
 	}
 
 	/**
@@ -1003,4 +1009,17 @@ class MembershipApplication {
 		$this->setDataObject( $dataObject );
 	}
 
+	/**
+	 * @param array $data
+	 * @return array
+	 */
+	private function truncateInsanelyLongFields( array $data ) {
+		foreach ( array_keys( $data ) as $key ) {
+			if ( is_string( $data[$key] ) ) {
+				$data[$key] = substr( $data[$key], 0, self::MAX_DATA_FIELD_LENGTH );
+			}
+		}
+
+		return $data;
+	}
 }

--- a/tests/unit/DonationTest.php
+++ b/tests/unit/DonationTest.php
@@ -155,6 +155,18 @@ class DonationTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testWhenDataFieldSizeExceedsLimit_dataFieldIsTruncated() {
+		$donation = new Donation();
+		$donation->encodeAndSetData( [
+			'tooLong' => str_repeat( 'cats! ', 2048 )
+		] );
+
+		$data = $donation->getDecodedData();
+
+		$this->assertSame( Donation::MAX_DATA_FIELD_LENGTH, strlen( $data['tooLong'] ) );
+
+	}
+
 	public function testStatusConstantsExist() {
 		$this->assertNotNull( Donation::STATUS_NEW );
 		$this->assertNotNull( Donation::STATUS_CANCELLED );

--- a/tests/unit/MembershipApplicationTest.php
+++ b/tests/unit/MembershipApplicationTest.php
@@ -171,4 +171,16 @@ class MembershipApplicationTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $application->isCancelled() );
 	}
 
+	public function testWhenDataFieldSizeExceedsLimit_dataFieldIsTruncated() {
+		$membershipApplication = new MembershipApplication();
+		$membershipApplication->encodeAndSetData( [
+			'tooLong' => str_repeat( 'cats! ', 2048 )
+		] );
+
+		$data = $membershipApplication->getDecodedData();
+
+		$this->assertSame( MembershipApplication::MAX_DATA_FIELD_LENGTH, strlen( $data['tooLong'] ) );
+
+	}
+
 }


### PR DESCRIPTION
The old fundraising frontend protected against maliciously long
fields, now we're doing the truncation at the persistence layer.

This is for https://phabricator.wikimedia.org/T136604