### PR TITLE
Remove covers-validator in CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.2",
 		"phpmd/phpmd": "~2.3",
-		"ockcyp/covers-validator": "~0.4.0"
+		"phpunit/phpunit": "~5.4"
 	},
 	"autoload": {
 		"psr-4": {
@@ -25,8 +25,7 @@
 	"scripts": {
 		"test": [
 			"composer validate --no-interaction",
-			"phpunit",
-			"vendor/bin/covers-validator"
+			"phpunit"
 		],
 		"cs": [
 			"composer phpcs",


### PR DESCRIPTION
This functitionality is integrated into PHPUnit since version 5.2.6

Require PHPUnit explicitly.