### PR TITLE
Bump up PHP version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: DB=sqlite
     - php: 7
       env: DB=mysql

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "wmde/fundraising-store",
 	"description": "Persistence services around the fundraising database",
 	"require": {
-		"php": ">=5.5.0",
+		"php": ">=5.6",
 		"doctrine/dbal": "~2.4",
 		"doctrine/orm": "~2.4",
 		"gedmo/doctrine-extensions": "^2.4"


### PR DESCRIPTION
As discussed https://github.com/wmde/FundraisingStore/pull/30 the component's requirement might be raised to PHP 5.6.
As all things using this component already require PHP >= 5.6 let's do it!
This will also simplify things in https://github.com/wmde/FundraisingStore/pull/86