### PR TITLE
[DNM] MembershipApplicationRepository draft

### DIFF
--- a/src/Store/MembershipApplicationRepository.php
+++ b/src/Store/MembershipApplicationRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace WMDE\Fundraising\Store;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMException;
+use WMDE\Fundraising\Entities\MembershipApplication;
+
+/**
+ * @since 2.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class MembershipApplicationRepository {
+
+	private $entityManager;
+
+	public function __construct( EntityManager $entityManager ) {
+		$this->entityManager = $entityManager;
+	}
+
+	/**
+	 * @param int $applicationId
+	 *
+	 * @return MembershipApplication|null
+	 * @throws MembershipApplicationRepositoryException
+	 */
+	public function getApplicationOrNullById( $applicationId ) {
+		try {
+			$application = $this->entityManager->find( MembershipApplication::class, $applicationId );
+		}
+		catch ( ORMException $ex ) {
+			throw new MembershipApplicationRepositoryException( 'Membership application could not be accessed' );
+		}
+
+		return $application;
+	}
+
+	/**
+	 * @param int $applicationId
+	 *
+	 * @return MembershipApplication
+	 * @throws MembershipApplicationRepositoryException
+	 */
+	public function getApplicationById( $applicationId ) {
+		$application = $this->getApplicationOrNullById( $applicationId );
+
+		if ( $application === null ) {
+			throw new MembershipApplicationRepositoryException( 'Membership application does not exist' );
+		}
+
+		return $application;
+	}
+
+	/**
+	 * @param MembershipApplication $application
+	 *
+	 * @throws MembershipApplicationRepositoryException
+	 */
+	public function persistApplication( MembershipApplication $application ) {
+		try {
+			$this->entityManager->persist( $application );
+		}
+		catch ( ORMException $ex ) {
+			throw new MembershipApplicationRepositoryException( 'Failed to persist membership application' );
+		}
+	}
+
+	/**
+	 * @param int $applicationId
+	 * @param callable $modificationFunction
+	 *
+	 * @throws MembershipApplicationRepositoryException
+	 */
+	public function modifyApplication( $applicationId, callable $modificationFunction ) {
+		$application = $this->getApplicationById( $applicationId );
+
+		$modificationFunction( $application );
+
+		$this->persistApplication( $application );
+	}
+
+	/**
+	 * @throws MembershipApplicationRepositoryException
+	 */
+	public function flush() {
+		try {
+			$this->entityManager->flush();
+		}
+		catch ( ORMException $ex ) {
+			throw new MembershipApplicationRepositoryException( 'Failed to persist membership application' );
+		}
+	}
+
+}

--- a/src/Store/MembershipApplicationRepositoryException.php
+++ b/src/Store/MembershipApplicationRepositoryException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Store;
+
+/**
+ * @since 2.0
+ *
+ * @license GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class MembershipApplicationRepositoryException extends \RuntimeException {
+
+	public function __construct( $message, \Exception $previous = null ) {
+		parent::__construct( $message, 0, $previous );
+	}
+
+}


### PR DESCRIPTION
In the frontend app we are repeating modification code of the membership
application doctrine entity at several places, including DoctrineMembershipApplicationPiwikTracker
and DoctrineMembershipApplicationTracker. Those services just need to modify an application
given by id. Yet the tests need to hold into account the various persistence failure cases.
Logging failures and similar cross cutting concerns need decorators for each such service,
all with their own tests as well.

This MembershipApplicationRepository is a way to share the duplicated code and make the
testing simpler.

Just trying things out here for now. Do not merge, tests in this component are missing. Also need new factory method.
