### PR TITLE
Clean up cli-config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ run style checks use `composer cs`.
 
 ## Release notes
 
+### Next Version (2.0.x)
+* Ability ro re-ruse the file `cli-config.php` when including `FundraisingStore` in an application is removed.
+
 ### Version 2.0 (2016-08-03)
 
 #### Breaking changes

--- a/cli-config.php
+++ b/cli-config.php
@@ -1,15 +1,17 @@
 <?php
-
+/**
+ * This script is for using the vendor/bin/doctrine command while developing
+ * the FundraisingStore library.
+ *
+ * If you include FundraisingStore in your application you'll have to create a similar file
+ * in your application root. That file should also initialize the database,
+ * using a configuration method that fits your application.
+ */
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
 use WMDE\Fundraising\Store\Factory;
 
-// Load config for both dependency and standalone use case
-if ( file_exists( __DIR__ . '/../../local-db-config.php' ) ) {
-	require_once( __DIR__ . '/../../local-db-config.php' );
-} else {
-	require_once( __DIR__ . '/local-db-config.php' );
-}
+require_once( __DIR__ . '/local-db-config.php' );
 
 $factory = new Factory( DriverManager::getConnection( [
 	'driver' => 'pdo_mysql',


### PR DESCRIPTION
cli-config.php is now only for using vendor/bin/doctrine while
developing FundraisingStore. Ability ro re-ruse the file when including
FundraisingStore in an application is turned off.