### PR TITLE
Positive subscription status

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ run style checks use `composer cs`.
 ### Version 2.2.0 (dev)
 
 * Changed the minimum PHP version to 7.0
+* Positive subscription status
+   * All status flags are now positive, for better usage with bitwise operators
+   * Removed flags that are not used anywhere.
+   * Renamed flag `STATUS_NEUTRAL` to `STATUS_NEW`.
 
 ### Version 2.1.0 (2016-10-10)
 

--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -84,13 +84,9 @@ class Subscription {
 	 */
 	private $createdAt;
 
+	const STATUS_NEW = 0;
 	const STATUS_CONFIRMED = 1;
-	const STATUS_NEUTRAL = 0;
-	const STATUS_DELETED = -1;
-	const STATUS_MODERATION = -2;
-	const STATUS_ABORTED = -4;
-	const STATUS_CANCELED = -8;
-
+	const STATUS_MODERATION = 2;
 
 	/**
 	 * Set name


### PR DESCRIPTION
After our painful experiences with negative bitwise status flags in the
membership applications, we want to do the status flags right from the
start, using only positive numbers.

Removed flags that are not used anywhere.

This change is possible because there is no data yet.