### PR TITLE
Fixed bug in Subscription::isUnconfirmed

### DIFF
--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -147,6 +147,10 @@ class Subscription {
 		return $this;
 	}
 
+	/**
+	 * Usage of this method is discouraged. Try using something like @see isUnconfirmed
+	 * @return int
+	 */
 	public function getStatus(): int {
 		return $this->status;
 	}
@@ -191,7 +195,7 @@ class Subscription {
 	}
 
 	public function isUnconfirmed(): bool {
-		return $this->getStatus() === self::STATUS_NEW;
+		return $this->getStatus() !== self::STATUS_CONFIRMED;
 	}
 
 	public function getHexConfirmationCode(): string {

--- a/tests/unit/SubscriptionTest.php
+++ b/tests/unit/SubscriptionTest.php
@@ -35,4 +35,11 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $subscription->isUnconfirmed() );
 	}
 
+	public function testIsUnconfirmedReturnsTrueForSubscriptionsPendingModeration() {
+		$subscription = new Subscription();
+		$subscription->setStatus( Subscription::STATUS_MODERATION );
+
+		$this->assertTrue( $subscription->isUnconfirmed() );
+	}
+
 }


### PR DESCRIPTION
As identified by @gbirke in https://github.com/wmde/FundraisingStore/pull/107

I did not go for the bitfield approach.

Bitfields are hard to understand and IMO
should not be used unless there is really good reason for such optimization.
And when that is done, it should be hidden as well as possible.

The more concrete reason which made me decide to change this now is that
bitfields imply you can have many of the possible values. AFAIK this is not
the case here. Does a combination of "confirmed" and "needs moderation"
make any sense? AFAIK not.