### PR TITLE
Add doc comments for deprecated method

### DIFF
--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -142,8 +142,10 @@ class Subscription {
 	}
 
 	/**
-	 * Usage of this method is discouraged.
-	 *
+	 * Usage of this method is discouraged, it's only for initialization with Doctrine.
+	 * 
+	 * @see Subscription::markAsConfirmed()
+ 	 * @see Subscription::markForModeration()
 	 * @param int $status
 	 * @return Subscription
 	 */


### PR DESCRIPTION
Mark `setStatus` as deprecated and show alternatives.

Followup to #110 