### PR TITLE
Added Subscription::needsModeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ run style checks use `composer cs`.
 * Added `Subscription::getSource` and `Subscription::setSource`
 * Added `Subscription::markAsConfirmed`
 * Added `Subscription::markForModeration`
+* Added `Subscription::needsModeration`
 
 #### Bug fixes
 

--- a/src/Entities/ActionLog.php
+++ b/src/Entities/ActionLog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Entities;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Entities/Address.php
+++ b/src/Entities/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Entities;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Entities/BackendBanner.php
+++ b/src/Entities/BackendBanner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Entities;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Entities/BackendImpression.php
+++ b/src/Entities/BackendImpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Entities;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Entities/Donation.php
+++ b/src/Entities/Donation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Entities;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -656,6 +658,10 @@ class Donation {
 	 * @return array
 	 */
 	public function getDecodedData() {
+		if ( $this->data === null ) {
+			return [];
+		}
+
 		$data = unserialize( base64_decode( $this->data ) );
 
 		return is_array( $data ) ? $data : [];

--- a/src/Entities/MembershipApplication.php
+++ b/src/Entities/MembershipApplication.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Entities;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -966,6 +968,10 @@ class MembershipApplication {
 	 * @return array
 	 */
 	public function getDecodedData() {
+		if ( $this->data === null ) {
+			return [];
+		}
+
 		$data = unserialize( base64_decode( $this->data ) );
 
 		return is_array( $data ) ? $data : [];

--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -204,7 +204,7 @@ class Subscription {
 	}
 
 	public function isUnconfirmed(): bool {
-		return $this->getStatus() !== $this->STATUS_CONFIRMED;
+		return $this->status !== $this->STATUS_CONFIRMED;
 	}
 
 	public function getHexConfirmationCode(): string {

--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Entities;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -93,6 +93,7 @@ class Subscription {
 	 */
 	private $createdAt;
 
+	// TODO: replace by private constants once using PHP 7.1+
 	private $STATUS_NEW = 0;
 	private $STATUS_CONFIRMED = 1;
 	private $STATUS_MODERATION = 2;
@@ -205,10 +206,6 @@ class Subscription {
 		$this->tracking = $tracking;
 	}
 
-	public function isUnconfirmed(): bool {
-		return $this->status !== $this->STATUS_CONFIRMED;
-	}
-
 	public function getHexConfirmationCode(): string {
 		return bin2hex( $this->confirmationCode );
 	}
@@ -245,6 +242,17 @@ class Subscription {
 	 */
 	public function markForModeration() {
 		$this->status = $this->STATUS_MODERATION;
+	}
+
+	public function isUnconfirmed(): bool {
+		return $this->status !== $this->STATUS_CONFIRMED;
+	}
+
+	/**
+	 * @since 3.0
+	 */
+	public function needsModeration(): bool {
+		return $this->status === $this->STATUS_MODERATION;
 	}
 
 }

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Entities;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Store/DonationData.php
+++ b/src/Store/DonationData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store;
 
 /**

--- a/src/Store/Factory.php
+++ b/src/Store/Factory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/src/Store/Installer.php
+++ b/src/Store/Installer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store;
 
 use Doctrine\ORM\EntityManager;

--- a/src/Store/MembershipApplicationData.php
+++ b/src/Store/MembershipApplicationData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store;
 
 /**

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store\Tests;
 
 use Doctrine\DBAL\DriverManager;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,11 +1,13 @@
 <?php
 
+declare( strict_types = 1 );
+
 if ( PHP_SAPI !== 'cli' ) {
 	die( 'Not an entry point' );
 }
 
-error_reporting( E_ALL | E_STRICT );
-ini_set( 'display_errors', 1 );
+error_reporting( -1 );
+ini_set( 'display_errors', '1' );
 
 if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );

--- a/tests/integration/AutoloaderTest.php
+++ b/tests/integration/AutoloaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store\Tests;
 
 use WMDE\Fundraising\Entities\ActionLog;

--- a/tests/integration/DatabaseInstallationTest.php
+++ b/tests/integration/DatabaseInstallationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store\Tests;
 
 /**

--- a/tests/integration/MembershipApplicationInsertionTest.php
+++ b/tests/integration/MembershipApplicationInsertionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store\Tests;
 
 use WMDE\Fundraising\Entities\MembershipApplication;

--- a/tests/unit/DonationTest.php
+++ b/tests/unit/DonationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store\Tests;
 
 use WMDE\Fundraising\Entities\Donation;

--- a/tests/unit/MembershipApplicationTest.php
+++ b/tests/unit/MembershipApplicationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store\Tests;
 
 use WMDE\Fundraising\Entities\MembershipApplication;

--- a/tests/unit/SubscriptionTest.php
+++ b/tests/unit/SubscriptionTest.php
@@ -1,9 +1,18 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Store\Tests;
 
 use WMDE\Fundraising\Entities\Subscription;
 
+/**
+ * @covers WMDE\Fundraising\Entities\Subscription
+ *
+ * @licence GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
 class SubscriptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGivenABinaryConfirmationCode_itCanBeConvertedToHex() {

--- a/tests/unit/SubscriptionTest.php
+++ b/tests/unit/SubscriptionTest.php
@@ -51,4 +51,17 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $subscription->isUnconfirmed() );
 	}
 
+	public function testWhenSubscriptionIsNew_needsModerationReturnsFalse() {
+		$subscription = new Subscription();
+
+		$this->assertFalse( $subscription->needsModeration() );
+	}
+
+	public function testWhenPendingModeration_needsModerationReturnsTrue() {
+		$subscription = new Subscription();
+		$subscription->markForModeration();
+
+		$this->assertTrue( $subscription->needsModeration() );
+	}
+
 }

--- a/tests/unit/SubscriptionTest.php
+++ b/tests/unit/SubscriptionTest.php
@@ -24,18 +24,18 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame( 'foobar', $subscription->getSource() );
 	}
 
-	public function testIsUnconfirmedReturnsTrueForNewSubscriptions() {
+	public function testWhenSubscriptionIsNew_isUnconfirmedReturnsTrue() {
 		$this->assertTrue( ( new Subscription() )->isUnconfirmed() );
 	}
 
-	public function testIsUnconfirmedReturnsFalseForConfirmedSubscriptions() {
+	public function testWhenConfirmed_isUnconfirmedReturnsFalse() {
 		$subscription = new Subscription();
 		$subscription->markAsConfirmed();
 
 		$this->assertFalse( $subscription->isUnconfirmed() );
 	}
 
-	public function testIsUnconfirmedReturnsTrueForSubscriptionsPendingModeration() {
+	public function testWhenPendingModeration_isUnconfirmedReturnsTrue() {
 		$subscription = new Subscription();
 		$subscription->markForModeration();
 


### PR DESCRIPTION
I had a look at if we where missing anything in the store for the frontend app to switch to store 3.0 now the status constants are gone. With this method added I think store 3.0 is ready for release.

This is done on top of some misc CS changes