### PR TITLE
Convert confirmation code to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ this package as well as its dependencies.
 To add this package as a local, per-project dependency to your project, simply add a
 dependency on `wmde/fundraising-store` to your project's `composer.json` file.
 Here is a minimal example of a `composer.json` file that just defines a dependency on
-Fundraising Store 3.x:
+Fundraising Store 4.x:
 
-```js
+```json
 {
     "require": {
-        "wmde/fundraising-store": "^3.0.0"
+        "wmde/fundraising-store": "^4.0.0"
     }
 }
 ```
@@ -43,6 +43,12 @@ required by our CI by executing `composer ci`. To just run tests use `composer t
 run style checks use `composer cs`.
 
 ## Release notes
+
+### Version 4.0.0 (2016-11-25)
+
+#### Breaking changes
+
+* The subscription confirmation code is now a plain string instead of a binary (blob). This makes it easier to read and test. 
 
 ### Version 3.0.0 (2016-11-16)
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.0.x-dev"
+			"dev-master": "4.0.x-dev"
 		}
 	},
 	"scripts": {

--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -53,7 +53,7 @@ class Subscription {
 	/**
 	 * @var string
 	 *
-	 * @ORM\Column(name="confirmationCode", type="blob", length=16, nullable=true)
+	 * @ORM\Column(name="confirmationCode", type="string", length=32, nullable=true)
 	 */
 	private $confirmationCode;
 
@@ -204,14 +204,6 @@ class Subscription {
 
 	public function setTracking( string $tracking ) {
 		$this->tracking = $tracking;
-	}
-
-	public function getHexConfirmationCode(): string {
-		return bin2hex( $this->confirmationCode );
-	}
-
-	public function setHexConfirmationCode( string $confirmationCode ) {
-		$this->confirmationCode = hex2bin( $confirmationCode );
 	}
 
 	/**

--- a/tests/unit/SubscriptionTest.php
+++ b/tests/unit/SubscriptionTest.php
@@ -15,18 +15,6 @@ use WMDE\Fundraising\Entities\Subscription;
  */
 class SubscriptionTest extends \PHPUnit_Framework_TestCase {
 
-	public function testGivenABinaryConfirmationCode_itCanBeConvertedToHex() {
-		$subscription = new Subscription();
-		$subscription->setConfirmationCode( 'Unicorns_Kittens' );
-		$this->assertSame( '556e69636f726e735f4b697474656e73', $subscription->getHexConfirmationCode() );
-	}
-
-	public function testGivenAHexConfirmationCode_itCanBeConvertedToBinary() {
-		$subscription = new Subscription();
-		$subscription->setHexConfirmationCode( '417765736f6d655f4d656f7773212121' );
-		$this->assertSame( 'Awesome_Meows!!!', $subscription->getConfirmationCode() );
-	}
-
 	public function testSetAndGetSource() {
 		$subscription = new Subscription();
 		$subscription->setSource( 'foobar' );


### PR DESCRIPTION
Storing binary strings in doctrine results field type of resource that's
difficult to test and read values from.

This is the first step for fixing https://github.com/wmde/fundraising/issues/1174