### PR TITLE
allow setting the proxy dir during creation of Factory

### DIFF
--- a/src/Store/Factory.php
+++ b/src/Store/Factory.php
@@ -23,9 +23,11 @@ use Gedmo\Timestampable\TimestampableListener;
 class Factory {
 
 	private $entityManager;
+	private $proxyDir;
 
-	public function __construct( Connection $connection ) {
+	public function __construct( Connection $connection, $proxyDir = '/tmp' ) {
 		$this->connection = $connection;
+		$this->proxyDir = $proxyDir;
 	}
 
 	/**
@@ -58,6 +60,7 @@ class Factory {
 		$driver = new AnnotationDriver( $annotationReader, $paths );
 		AnnotationRegistry::registerLoader( 'class_exists' );
 		$config->setMetadataDriverImpl( $driver );
+		$config->setProxyDir( $this->proxyDir );
 
 		$eventManager = $this->connection->getEventManager();
 		$timestampableListener = new TimestampableListener;

--- a/tests/integration/FactoryTest.php
+++ b/tests/integration/FactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Store\Tests;
+
+use Doctrine\DBAL\DriverManager;
+use WMDE\Fundraising\Store\Factory;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class FactoryTest extends \PHPUnit_Framework_TestCase {
+
+	const PROXY_PATH = '/path/to/proxy/classes/';
+
+	public function testGivenCustomProxyDir_itIsPassedToProxyGenerator() {
+		$factory = new Factory( $this->newConnection(), self::PROXY_PATH );
+		$this->assertSame( self::PROXY_PATH, $factory->getEntityManager()->getConfiguration()->getProxyDir() );
+	}
+
+	private function newConnection() {
+		return DriverManager::getConnection( [ 'driver' => 'pdo_sqlite', 'memory' => true ] );
+	}
+
+}


### PR DESCRIPTION
Whenever an entity relates to another by foreign key, Doctrine uses proxy classes. The directory in which generated proxy classes are stored can only be set during creation of the `EntityManager`. This patch introduces the possibility to pass the proxy dir to `Factory::__construct()`.