### PR TITLE
use trusty on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: required
+
 language: php
 
 matrix:
@@ -6,8 +9,6 @@ matrix:
       env: DB=sqlite; TYPE=coverage
     - php: 7.1
       env: DB=mysql
-
-sudo: true
 
 install:
   - if [ "$DB" == "mysql" ]; then mysql -e 'create database spenden;'; fi


### PR DESCRIPTION
Switching to `trusty` as per https://docs.travis-ci.com/user/database-setup/#MySQL-5.6.