### PR TITLE
Use associations for donation payment entity

### DIFF
--- a/src/Entities/Donation.php
+++ b/src/Entities/Donation.php
@@ -205,6 +205,11 @@ class Donation {
 	private $dtBackup;
 
 	/**
+	 * @ORM\OneToOne(targetEntity="WMDE\Fundraising\Entities\DonationPayment", cascade={"all"}, fetch="EAGER")
+	 */
+	private $payment;
+
+	/**
 	 * @param string $donorFullName
 	 *
 	 * @return self
@@ -593,6 +598,15 @@ class Donation {
 	public function getId() {
 		return $this->id;
 	}
+
+	public function getPayment(): ?DonationPayment {
+		return $this->payment;
+	}
+
+	public function setPayment( DonationPayment $payment ) {
+		$this->payment = $payment;
+	}
+
 
 	/**
 	 * @since 2.0

--- a/src/Entities/DonationPayment.php
+++ b/src/Entities/DonationPayment.php
@@ -1,0 +1,36 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\Entities;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @since 6.0
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="donation_payment")
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="payment_type", type="string", length=3)
+ * @ORM\DiscriminatorMap({"SUB" = "WMDE\Fundraising\Entities\DonationPayments\SofortPayment"})
+ */
+abstract class DonationPayment {
+
+	/**
+	 * @var integer
+	 *
+	 * @ORM\Column(name="id", type="integer")
+	 * @ORM\GeneratedValue(strategy="IDENTITY")
+	 * @ORM\Id
+	 */
+	private $id;
+
+	public function getId(): int {
+		return $this->id;
+	}
+
+	public function setId( int $id ): void {
+		$this->id = $id;
+	}
+
+}

--- a/src/Entities/DonationPayments/SofortPayment.php
+++ b/src/Entities/DonationPayments/SofortPayment.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Entities\DonationPayments;
 
 use Doctrine\ORM\Mapping as ORM;
+use WMDE\Fundraising\Entities\DonationPayment;
 
 /**
  * @since 6.0
@@ -12,36 +13,22 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Table(name="donation_payment_sofort")
  * @ORM\Entity
  */
-class SofortPayment {
+class SofortPayment extends DonationPayment {
 
 	/**
 	 * @var string
 	 * Example value: W-Q-ABCDEZ
 	 *
 	 * @ORM\Column(name="transfer_code", type="string", length=10, unique=true)
-	 * @ORM\Id
 	 */
 	private $bankTransferCode = '';
 
-	/**
-	 * @var integer
-	 * Example value: 1337
-	 *
-	 * @ORM\Column(name="donation_id", type="integer", unique=true)
-	 */
-	private $donationId = '';
-
-	public function __construct( string $bankTransferCode, int $donationId ) {
+	public function __construct( string $bankTransferCode ) {
 		$this->bankTransferCode = $bankTransferCode;
-		$this->donationId = $donationId;
 	}
 
 	public function getBankTransferCode(): string {
 		return $this->bankTransferCode;
-	}
-
-	public function getDonationId(): int {
-		return $this->donationId;
 	}
 
 }

--- a/src/Entities/DonationPayments/SofortPayment.php
+++ b/src/Entities/DonationPayments/SofortPayment.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Entities\DonationPayments;
 
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use WMDE\Fundraising\Entities\DonationPayment;
 
@@ -23,6 +24,13 @@ class SofortPayment extends DonationPayment {
 	 */
 	private $bankTransferCode = '';
 
+	/**
+	 * @var DateTime
+	 *
+	 * @ORM\Column(name="confirmed_at", type="datetime", nullable=true)
+	 */
+	private $confirmedAt;
+
 	public function __construct( string $bankTransferCode ) {
 		$this->bankTransferCode = $bankTransferCode;
 	}
@@ -31,4 +39,11 @@ class SofortPayment extends DonationPayment {
 		return $this->bankTransferCode;
 	}
 
+	public function getConfirmedAt(): ?DateTime {
+		return $this->confirmedAt;
+	}
+
+	public function setConfirmedAt( DateTime $confirmedAt ) {
+		$this->confirmedAt = $confirmedAt;
+	}
 }

--- a/tests/integration/DatabaseInstallationTest.php
+++ b/tests/integration/DatabaseInstallationTest.php
@@ -41,6 +41,7 @@ class DatabaseInstallationTest extends TestCase {
 		yield [ 'spenden' ];
 		yield [ 'subscription' ];
 		yield [ 'users' ];
+		yield [ 'donation_payment' ];
 		yield [ 'donation_payment_sofort' ];
 	}
 

--- a/tests/integration/SofortPaymentTest.php
+++ b/tests/integration/SofortPaymentTest.php
@@ -5,10 +5,11 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Store\Tests;
 
 use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\Entities\Donation;
 use WMDE\Fundraising\Entities\DonationPayments\SofortPayment;
 
 /**
- * @covers WMDE\Fundraising\Entities\DonationPayments\SofortPayment
+ * @covers \WMDE\Fundraising\Entities\DonationPayments\SofortPayment
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -16,21 +17,23 @@ use WMDE\Fundraising\Entities\DonationPayments\SofortPayment;
 class SofortPaymentTest extends TestCase {
 
 	private const BANK_TRANSFER_CODE = 'W-Q-ABCDEZ';
-	private const DONATION_ID = 31337;
 
 	public function testPersistenceRoundTrip() {
-		$payment = new SofortPayment( self::BANK_TRANSFER_CODE, self::DONATION_ID );
+		$donation = new Donation();
+		$payment = new SofortPayment( self::BANK_TRANSFER_CODE );
+		$donation->setPayment( $payment );
 		$entityManager = TestEnvironment::newDefault()->getFactory()->getEntityManager();
 
-		$entityManager->persist( $payment );
+		$entityManager->persist( $donation );
 		$entityManager->flush();
 		/**
 		 * @var $retrievedPayment SofortPayment
 		 */
-		$retrievedPayment = $entityManager->getRepository( SofortPayment::class )->find( self::BANK_TRANSFER_CODE );
+		$retrievedPayment = $entityManager->getRepository( SofortPayment::class )
+			->findOneByBankTransferCode( self::BANK_TRANSFER_CODE );
 
 		$this->assertSame( self::BANK_TRANSFER_CODE, $retrievedPayment->getBankTransferCode() );
-		$this->assertSame( self::DONATION_ID, $retrievedPayment->getDonationId() );
+		$this->assertSame( $payment->getId(), $retrievedPayment->getId() );
 	}
 
 }


### PR DESCRIPTION
Payment is now an abstract class, with one implementation -
SofortPayment. Other payments will still use the legacy method of
storing the payment data in the data blob and setting
Donation::paymentType.

Future versions of the store may move the other payment data out of the
data blob until the paymentType property of Donation can be dropped.