### PR TITLE
T167882 sofort's confirmedAt is nullable on the db level

### DIFF
--- a/src/Entities/DonationPayments/SofortPayment.php
+++ b/src/Entities/DonationPayments/SofortPayment.php
@@ -17,7 +17,7 @@ use WMDE\Fundraising\Entities\DonationPayment;
 class SofortPayment extends DonationPayment {
 
 	/**
-	 * @var DateTime
+	 * @var DateTime|null
 	 *
 	 * @ORM\Column(name="confirmed_at", type="datetime", nullable=true)
 	 */
@@ -27,7 +27,7 @@ class SofortPayment extends DonationPayment {
 		return $this->confirmedAt;
 	}
 
-	public function setConfirmedAt( DateTime $confirmedAt ) {
+	public function setConfirmedAt( DateTime $confirmedAt = null ): void {
 		$this->confirmedAt = $confirmedAt;
 	}
 }

--- a/tests/integration/SofortPaymentTest.php
+++ b/tests/integration/SofortPaymentTest.php
@@ -17,10 +17,9 @@ use WMDE\Fundraising\Entities\DonationPayments\SofortPayment;
  */
 class SofortPaymentTest extends TestCase {
 
-	public function testPersistenceRoundTrip() {
+	public function testPersistenceRoundTrip(): void {
 		$donation = new Donation();
 		$payment = new SofortPayment();
-		$payment->setConfirmedAt( new DateTime( '2017-07-14T22:00:01Z' ) );
 		$donation->setPayment( $payment );
 
 		$entityManager = TestEnvironment::newDefault()->getFactory()->getEntityManager();
@@ -33,7 +32,20 @@ class SofortPaymentTest extends TestCase {
 		$retrievedPayment = $entityManager->getRepository( SofortPayment::class )
 			->findOneBy( [] );
 
-		$this->assertEquals( new DateTime( '2017-07-14T22:00:01Z' ), $retrievedPayment->getConfirmedAt() );
 		$this->assertSame( $payment->getId(), $retrievedPayment->getId() );
+		$this->assertNull( $retrievedPayment->getConfirmedAt() );
+
+		$payment->setConfirmedAt( new DateTime( '2017-07-14T22:00:01Z' ) );
+		$entityManager->persist( $donation );
+		$entityManager->flush();
+
+		/**
+		 * @var $retrievedPayment SofortPayment
+		 */
+		$retrievedPayment = $entityManager->getRepository( SofortPayment::class )
+			->findOneBy( [] );
+
+		$this->assertSame( $payment->getId(), $retrievedPayment->getId() );
+		$this->assertEquals( new DateTime( '2017-07-14T22:00:01Z' ), $retrievedPayment->getConfirmedAt() );
 	}
 }


### PR DESCRIPTION
Code should match annotations, not put business logic ("no undo of confirm") into data access classes.