### PR TITLE
Update Doctrine

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Be aware that the concepts of composer as a script runner and containerization m
 
 ## Release notes
 
+### Version 6.0.1 (2017-08-02)
+
 ### Version 6.0.0 (2017-07-18)
 
 * Added `DonationPayments\SofortPayment` entity

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
 	"license": "GPL-2.0+",
 	"require": {
 		"php": ">=7.1",
-		"doctrine/dbal": "~2.4",
-		"doctrine/orm": "~2.4",
+		"doctrine/dbal": "^2.5",
+		"doctrine/orm": "^2.5",
 		"gedmo/doctrine-extensions": "^2.4"
 	},
 	"require-dev": {


### PR DESCRIPTION
Release 5.0 introduced an annotation that did not exist in Doctrine
versions before 2.5. This lead to failing unit tests in some cases where
the library was not updated.