### PR TITLE
add status 'exported' for donations

### DIFF
--- a/src/Entities/Donation.php
+++ b/src/Entities/Donation.php
@@ -41,6 +41,13 @@ class Donation {
 	public const STATUS_CANCELLED = 'D';
 
 	/**
+	 * @since 6.1
+	 * @deprecated since 6.1; This status is defined for historical reasons. It should not be used to define a
+	 * donation's status anymore.
+	 */
+	public const STATUS_EXPORTED = 'E';
+
+	/**
 	 * @var integer
 	 *
 	 * @ORM\Column(name="id", type="integer")

--- a/tests/unit/DonationTest.php
+++ b/tests/unit/DonationTest.php
@@ -165,6 +165,7 @@ class DonationTest extends TestCase {
 		$this->assertNotNull( Donation::STATUS_EXTERNAL_INCOMPLETE );
 		$this->assertNotNull( Donation::STATUS_MODERATION );
 		$this->assertNotNull( Donation::STATUS_PROMISE );
+		$this->assertNotNull( Donation::STATUS_EXPORTED );
 	}
 
 }


### PR DESCRIPTION
This PR adds (and deprecates) the constant `Donation::STATUS_EXPORTED` as discussed in [wmde/fundraising-backend#297](https://github.com/wmde/fundraising-backend/pull/297#discussion_r133238025).