### PR TITLE
New default value for timestamp

### DIFF
--- a/src/Entities/ActionLog.php
+++ b/src/Entities/ActionLog.php
@@ -17,7 +17,7 @@ class ActionLog {
 	 * @var \DateTime
 	 *
 	 * @ORM\Version
-	 * @ORM\Column(name="al_timestamp", type="datetime", options={"default":0}, nullable=false)
+	 * @ORM\Column(name="al_timestamp", type="datetime", options={"default":"CURRENT_TIMESTAMP"}, nullable=false)
 	 */
 	private $alTimestamp = 0;
 


### PR DESCRIPTION
MySQL >= 5.7.x does stricter checking of data, for example not allowing
zeroes or `0000-00-00` as dates (see
https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date)

This PR fixes errors when the dev environment is rebuilt.