### PR TITLE
Add AddressChange entity to constructor and create migration script

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -18,3 +18,4 @@ tools:
 filter:
     excluded_paths:
         - 'vendor/*'
+        - 'migrations/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 matrix:
   include:
-    - php: 7.1
+    - php: 7.2
       env: DB=sqlite; TYPE=coverage
     - php: 7.2
       env: DB=mysql
@@ -14,7 +14,9 @@ install:
   - if [ "$DB" == "mysql" ]; then mysql -e 'create database spenden;'; fi
   - travis_retry composer install
 
-script: composer ci
+script:
+  - composer validate --no-interaction
+  - make ci
 
 after_success: bash tests/uploadCoverage.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+ci: covers phpunit cs
+
+test: covers phpunit
+
+covers:
+	docker-compose run --rm app ./vendor/bin/covers-validator
+
+phpunit:
+	docker-compose run --rm app ./vendor/bin/phpunit
+
+cs:
+	docker-compose run --rm app ./vendor/bin/phpcs
+
+.PHONY: covers phpunit cs stan

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,10 @@
 		"php": ">=7.1",
 		"doctrine/dbal": "^2.5",
 		"doctrine/orm": "^2.5",
+		"doctrine/migrations": "~1.8",
 		"gedmo/doctrine-extensions": "^2.4",
-		"ramsey/uuid": "^3.7"
+		"ramsey/uuid": "^3.7",
+		"symfony/yaml": "~4.1"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~3.0",

--- a/migrations.yml
+++ b/migrations.yml
@@ -1,0 +1,4 @@
+name: Doctrine Migration Scripts
+migrations_namespace: DoctrineMigrations
+table_name: doctrine_migration_versions
+migrations_directory: migrations

--- a/migrations/Version20180612000000.php
+++ b/migrations/Version20180612000000.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * This class adds the AddressChange table
+ * and adds a foreign key relationship to the donation and membership application tables
+ *
+ * This script should only be executed in maintenance mode, as the ALTER table queries may take a while to process
+ *
+ * @package DoctrineMigrations
+ */
+class Version20180612000000 extends AbstractMigration {
+
+	private const DB_QUERY_PAGE_SIZE = 1000;
+	private const DB_TABLE_DONATIONS = 'spenden';
+	private const DB_TABLE_MEMBERSHIP_APPLICATIONS = 'request';
+
+	/**
+	 * @param Schema $schema
+	 *
+	 * @throws \Exception
+	 */
+	public function up( Schema $schema ): void {
+		$this->abortIf(
+			$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+			'Migration can only be executed safely on \'mysql\'.'
+		);
+		$this->skipIf( $schema->hasTable( 'address_change' ), 'AddressChange table already exists' );
+
+		$this->addSql('CREATE TABLE address_change (id INT AUTO_INCREMENT NOT NULL, address_id INT DEFAULT NULL, current_identifier VARCHAR(36) DEFAULT NULL, previous_identifier VARCHAR(36) DEFAULT NULL, UNIQUE INDEX UNIQ_7B0E7B9FA8954A18 (current_identifier), UNIQUE INDEX UNIQ_7B0E7B9F2EC1D3 (previous_identifier), INDEX IDX_7B0E7B9FF5B7AF75 (address_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+		$this->addSql('ALTER TABLE address_change ADD CONSTRAINT FK_7B0E7B9FF5B7AF75 FOREIGN KEY (address_id) REFERENCES address (id)');
+		$this->addSql('ALTER TABLE spenden ADD address_change_id INT DEFAULT NULL');
+		$this->addSql('ALTER TABLE spenden ADD CONSTRAINT FK_3CBBD045BB7DB7BC FOREIGN KEY (address_change_id) REFERENCES address_change (id)');
+		$this->addSql('CREATE UNIQUE INDEX UNIQ_3CBBD045BB7DB7BC ON spenden (address_change_id)');
+		$this->addSql('ALTER TABLE request ADD address_change_id INT DEFAULT NULL');
+		$this->addSql('ALTER TABLE request ADD CONSTRAINT FK_3B978F9FBB7DB7BC FOREIGN KEY (address_change_id) REFERENCES address_change (id)');
+		$this->addSql('CREATE UNIQUE INDEX UNIQ_3B978F9FBB7DB7BC ON request (address_change_id)');
+	}
+
+	/**
+	 * @param Schema $schema
+	 *
+	 * @throws \Doctrine\DBAL\DBALException
+	 */
+	public function postUp(Schema $schema)
+	{
+		$this->updateAddressChangeForeignKeys( self::DB_TABLE_DONATIONS );
+		$this->updateAddressChangeForeignKeys( self::DB_TABLE_MEMBERSHIP_APPLICATIONS );
+	}
+
+	/**
+	 * @param $table
+	 *
+	 * @throws \Doctrine\DBAL\DBALException
+	 */
+	private function updateAddressChangeForeignKeys( $table ): void {
+		$entityCount = $this->getAddressChangeNullColumnCount( $table );
+		$pageCount = (int) ($entityCount / self::DB_QUERY_PAGE_SIZE);
+		$currentAddressChangeId = $this->getHighestAddressChangeId();
+		$this->connection->beginTransaction();
+		$query = '';
+
+		for ( $currentEntity = 0; $currentEntity < $entityCount; $currentEntity++ ) {
+			$query .= 'INSERT INTO address_change ( current_identifier ) VALUES ( "' . Uuid::uuid4()->toString() . '" );';
+			if ( $currentEntity % self::DB_QUERY_PAGE_SIZE === 0 || $entityCount - 1 === $currentEntity ) {
+				$stmt = $this->connection->prepare( $query );
+				$stmt->execute();
+				$stmt->closeCursor();
+				$this->connection->commit();
+
+				if ($entityCount - 1 !== $currentEntity) {
+					$this->connection->beginTransaction();
+				}
+				echo $currentEntity . " AddressChange entitites committed\n";
+				$query = '';
+			}
+		}
+
+		for ( $page = 0; $page < $pageCount; $page++ ) {
+			$entities = $this->getPageForTable( $table );
+			echo 'Page: ' . $page . ' / ' . $pageCount . "\n";
+			foreach ( $entities as $entity ) {
+				$currentAddressChangeId++;
+				echo 'UPDATE ' . $table . ' SET address_change_id = '. $currentAddressChangeId . ' WHERE id = ' . (int) $entity['id'] . "\n";
+				$this->connection->executeUpdate(
+					'UPDATE ' . $table . ' SET address_change_id = ? WHERE id = ?',
+					[ $currentAddressChangeId, (int) $entity['id'] ]
+				);
+			}
+		}
+	}
+
+	private function getAddressChangeNullColumnCount( $table ): int {
+		$queryBuilder = $this->connection->createQueryBuilder();
+		$queryBuilder->select( 'COUNT(id)' )
+			->from( $table, $table )
+			->where( 'address_change_id is NULL' );
+
+		return $queryBuilder->execute()->fetchColumn( 0 );
+	}
+
+	private function getPageForTable( string $table ): Statement {
+		$queryBuilder = $this->connection->createQueryBuilder();
+		$queryBuilder->select( 'id' )
+			->from( $table )
+			->where( 'address_change_id is NULL' )
+			->orderBy('id', 'ASC')
+			->setMaxResults(  self::DB_QUERY_PAGE_SIZE );
+		return $queryBuilder->execute();
+	}
+
+	private function getHighestAddressChangeId(): int {
+		$dbResult = $this->connection->createQueryBuilder()
+			->select('id')
+			->from('address_change')
+			->orderBy('id', 'DESC')
+			->setMaxResults(1)
+			->execute()->fetchColumn(0);
+		return (int) $dbResult;
+	}
+
+	/**
+	 * @param Schema $schema
+	 *
+	 * @throws \Doctrine\DBAL\DBALException
+	 * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+	 */
+	public function down(Schema $schema): void
+	{
+		$this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+		$this->addSql('ALTER TABLE spenden DROP FOREIGN KEY FK_3CBBD045BB7DB7BC');
+		$this->addSql('ALTER TABLE request DROP FOREIGN KEY FK_3B978F9FBB7DB7BC');
+		$this->addSql('DROP TABLE address_change');
+		$this->addSql('DROP INDEX UNIQ_3B978F9FBB7DB7BC ON request');
+		$this->addSql('ALTER TABLE request DROP address_change_id');
+		$this->addSql('DROP INDEX UNIQ_3CBBD045BB7DB7BC ON spenden');
+		$this->addSql('ALTER TABLE spenden DROP address_change_id');
+	}
+}

--- a/src/Entities/AddressChange.php
+++ b/src/Entities/AddressChange.php
@@ -33,20 +33,17 @@ class AddressChange {
 	/**
 	 * @var string
 	 *
-	 * @ORM\Column(name="current_identifier", type="string", length=36, nullable=true)
+	 * @ORM\Column(name="current_identifier", type="string", length=36, nullable=true, unique=true)
 	 */
 	private $identifier;
 
 	/**
 	 * @var string
 	 *
-	 * @ORM\Column(name="previous_identifier", type="string", length=36, nullable=true)
+	 * @ORM\Column(name="previous_identifier", type="string", length=36, nullable=true, unique=true)
 	 */
 	private $previousIdentifier;
 
-	/**
-	 * Ensure that every AddressChange object gets a UUID but do not overwrite pre-fetched Doctrine values
-	 */
 	public function __construct() {
 		if ($this->identifier === null) {
 			$this->generateUuid();

--- a/src/Entities/Donation.php
+++ b/src/Entities/Donation.php
@@ -218,8 +218,13 @@ class Donation {
 
 	/**
 	 * @ORM\OneToOne(targetEntity="WMDE\Fundraising\Entities\AddressChange", cascade={"all"}, fetch="EAGER")
+	 * @ORM\JoinColumn(name="address_change_id", referencedColumnName="id")
 	 */
 	private $addressChange;
+
+	public function __construct() {
+		$this->addressChange = new AddressChange();
+	}
 
 	/**
 	 * @param string $donorFullName
@@ -777,7 +782,7 @@ class Donation {
 	 *
 	 * @return AddressChange
 	 */
-	public function getAddressChange(): ?AddressChange {
+	public function getAddressChange(): AddressChange {
 		return $this->addressChange;
 	}
 
@@ -785,13 +790,11 @@ class Donation {
 	 * Set AddressChange reference
 	 *
 	 * @since 8.0
+	 * @param $addressChange AddressChange
 	 *
-	 * @param AddressChange $addressChange
-	 * @return self
+	 * @return AddressChange
 	 */
-	public function setAddressChange(AddressChange $addressChange): self {
-		$this->addressChange = $addressChange;
-
-		return $this;
+	public function setAddressChange(AddressChange $addressChange) {
+		return $this->addressChange = $addressChange;
 	}
 }

--- a/src/Entities/MembershipApplication.php
+++ b/src/Entities/MembershipApplication.php
@@ -291,8 +291,16 @@ class MembershipApplication {
 
 	/**
 	 * @ORM\OneToOne(targetEntity="AddressChange", cascade={"all"}, fetch="EAGER")
+	 * @ORM\JoinColumn(name="address_change_id", referencedColumnName="id")
 	 */
 	private $addressChange;
+
+	/**
+	 * Donation constructor creates a new AddressChange entity unless one is supplied by Doctrine
+	 */
+	public function __construct() {
+		$this->addressChange = new AddressChange();
+	}
 
 	/**
 	 * @return integer
@@ -1104,7 +1112,7 @@ class MembershipApplication {
 	 *
 	 * @return AddressChange
 	 */
-	public function getAddressChange(): ?AddressChange {
+	public function getAddressChange(): AddressChange {
 		return $this->addressChange;
 	}
 
@@ -1112,13 +1120,11 @@ class MembershipApplication {
 	 * Set AddressChange reference
 	 *
 	 * @since 8.0
+	 * @param $addressChange AddressChange
 	 *
-	 * @param AddressChange $addressChange
-	 * @return self
+	 * @return AddressChange
 	 */
-	public function setAddressChange(AddressChange $addressChange): self {
-		$this->addressChange = $addressChange;
-
-		return $this;
+	public function setAddressChange(AddressChange $addressChange) {
+		return $this->addressChange = $addressChange;
 	}
 }

--- a/tests/unit/AddressChangeTest.php
+++ b/tests/unit/AddressChangeTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Store\Tests;
 
+use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
 use WMDE\Fundraising\Entities\AddressChange;
 
@@ -12,14 +13,22 @@ use WMDE\Fundraising\Entities\AddressChange;
  */
 class AddressChangeTest extends TestCase {
 
+	/**
+	 * @var EntityManager
+	 */
+	private $entityManager;
+
+	public function setUp(): void {
+		$this->entityManager = TestEnvironment::newDefault()->getFactory()->getEntityManager();
+	}
+
 	public function testWhenNewAddressChangeIsPersisted_uuidIsGeneratedAndStored() {
 		$addressChange = new AddressChange();
-		$entityManager = TestEnvironment::newDefault()->getFactory()->getEntityManager();
-		$entityManager->persist( $addressChange );
-		$entityManager->flush();
+		$this->entityManager->persist( $addressChange );
+		$this->entityManager->flush();
 
 		/** @var AddressChange $retrievedAddressChange */
-		$retrievedAddressChange = $entityManager->getRepository( AddressChange::class )->findOneBy( [] );
+		$retrievedAddressChange = $this->entityManager->getRepository( AddressChange::class )->findOneBy( [] );
 
 		$this->assertSame( $addressChange->getCurrentIdentifier(), $retrievedAddressChange->getCurrentIdentifier() );
 	}

--- a/tests/unit/DonationAddressChangeTest.php
+++ b/tests/unit/DonationAddressChangeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Store\Tests;
+
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\Entities\Donation;
+
+/**
+ * @covers WMDE\Fundraising\Entities\AddressChange
+ */
+class DonationAddressChangeTest extends TestCase {
+
+	/**
+	 * @var EntityManager
+	 */
+	private $entityManager;
+
+	public function setUp(): void {
+		$this->entityManager = TestEnvironment::newDefault()->getFactory()->getEntityManager();
+	}
+
+	public function testWhenDonationIsCreated_addressChangeUuidIsStored(): void {
+		$donation = new Donation();
+
+		$oldId = $donation->getAddressChange()->getCurrentIdentifier();
+		$this->entityManager->persist( $donation );
+		$this->entityManager->flush();
+
+		/** @var Donation $persistedDonation */
+		$persistedDonation = $this->entityManager->find( Donation::class, 1 );
+		$this->assertSame(
+			$oldId,
+			$persistedDonation->getAddressChange()->getCurrentIdentifier()
+		);
+	}
+
+	public function testWhenAddressIsUpdated_addressChangeUuidIsUpdated(): void {
+		$donation = new Donation();
+
+		$oldId = $donation->getAddressChange()->getCurrentIdentifier();
+
+		$this->entityManager->persist( $donation );
+		$this->entityManager->flush();
+
+		/** @var Donation $persistedDonation */
+		$persistedDonation = $this->entityManager->find( Donation::class, 1 );
+
+		$this->assertNull( $persistedDonation->getAddressChange()->getPreviousIdentifier() );
+
+		$persistedDonation->getAddressChange()->updateAddressIdentifier();
+
+		$this->assertNotSame( $oldId, $persistedDonation->getAddressChange()->getCurrentIdentifier() );
+		$this->assertSame( $oldId, $persistedDonation->getAddressChange()->getPreviousIdentifier() );
+	}
+}

--- a/tests/unit/MembershipAddressChangeTest.php
+++ b/tests/unit/MembershipAddressChangeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Store\Tests;
+
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\Entities\MembershipApplication;
+
+/**
+ * @covers WMDE\Fundraising\Entities\AddressChange
+ */
+class MembershipAddressChangeTest extends TestCase {
+
+	/**
+	 * @var EntityManager
+	 */
+	private $entityManager;
+
+	public function setUp(): void {
+		$this->entityManager = TestEnvironment::newDefault()->getFactory()->getEntityManager();
+	}
+
+	public function testWhenMembershipApplicationIsCreated_addressChangeUuidIsStored(): void {
+		$application = new MembershipApplication();
+
+		$oldId = $application->getAddressChange()->getCurrentIdentifier();
+		$this->entityManager->persist( $application );
+		$this->entityManager->flush();
+
+		/** @var MembershipApplication $persistedApplication */
+		$persistedApplication = $this->entityManager->find( MembershipApplication::class, 1 );
+		$this->assertSame(
+			$oldId,
+			$persistedApplication->getAddressChange()->getCurrentIdentifier()
+		);
+	}
+
+	public function testWhenAddressIsUpdated_addressChangeUuidIsUpdated(): void {
+		$application = new MembershipApplication();
+
+		$oldId = $application->getAddressChange()->getCurrentIdentifier();
+
+		$this->entityManager->persist( $application );
+		$this->entityManager->flush();
+
+		/** @var MembershipApplication $persistedApplication */
+		$persistedApplication = $this->entityManager->find( MembershipApplication::class, 1 );
+
+		$this->assertNull( $persistedApplication->getAddressChange()->getPreviousIdentifier() );
+
+		$persistedApplication->getAddressChange()->updateAddressIdentifier();
+
+		$this->assertNotSame( $oldId, $persistedApplication->getAddressChange()->getCurrentIdentifier() );
+		$this->assertSame( $oldId, $persistedApplication->getAddressChange()->getPreviousIdentifier() );
+	}
+}


### PR DESCRIPTION
T196333

Since Donation and Membership have a OneToOne relationship to AddressChange, it makes sense to me that the AddressChange entity is instantiated in their constructors rather than some "prePersist" event hook in two other repositories which is the purpose of this change.