### PR TITLE
Make AddressChange nullable for anon donations

### DIFF
--- a/src/Entities/Donation.php
+++ b/src/Entities/Donation.php
@@ -778,7 +778,7 @@ class Donation {
 	 *
 	 * @return AddressChange
 	 */
-	public function getAddressChange(): AddressChange {
+	public function getAddressChange(): ?AddressChange {
 		return $this->addressChange;
 	}
 


### PR DESCRIPTION
Donations can be anonymous and for these cases, FundraisingStore needs to be able to return `null` on `getAddressChange()`.