### PR TITLE
Add export date to AddressChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Be aware that the concepts of composer as a script runner and containerization m
 
 ## Release notes
 
+### Version 10.2.0 (2019-01-18)
+
+* Add `exportDate` to `AddressChange`
+
 ### Version 10.1.0 (2019-01-16)
 
 * Remove `thirdPartyIdentifier` from `AddressChange`

--- a/migrations/Version20190109000000.php
+++ b/migrations/Version20190109000000.php
@@ -28,8 +28,9 @@ final class Version20190109000000 extends AbstractMigration {
 			'Migration can only be executed safely on \'mysql\'.'
 		);
 		$this->addSql(
-			'ALTER TABLE address_change ADD address_type VARCHAR(10) NOT NULL'
+			'ALTER TABLE address_change ADD address_type VARCHAR(10) NOT NULL, ADD export_date DATETIME'
 		);
+		$this->addSql( 'CREATE INDEX ac_export_date ON address_change (export_date)' );
 	}
 
 	public function postUp( Schema $schema ) {
@@ -111,6 +112,7 @@ final class Version20190109000000 extends AbstractMigration {
 			$this->connection->getDatabasePlatform()->getName() !== 'mysql',
 			'Migration can only be executed safely on \'mysql\'.'
 		);
-		$this->addSql( 'ALTER TABLE address_change DROP address_type' );
+		$this->addSql( 'DROP INDEX ac_export_date ON address_change' );
+		$this->addSql( 'ALTER TABLE address_change DROP address_type, DROP export_date' );
 	}
 }

--- a/src/Entities/AddressChange.php
+++ b/src/Entities/AddressChange.php
@@ -10,7 +10,12 @@ use Ramsey\Uuid\Uuid;
 /**
  * @since 8.0
  *
- * @ORM\Table( name="address_change" )
+ * @ORM\Table(
+ *     name="address_change",
+ *     indexes={
+ *     	@ORM\Index(name="ac_export_date", columns={"export_date"})
+ *     }
+ * )
  * @ORM\Entity
  */
 class AddressChange {
@@ -54,6 +59,17 @@ class AddressChange {
 	 * @ORM\Column(name="address_type", type="string", length = 10)
 	 */
 	private $addressType;
+
+	/**
+	 * Date of last export
+	 *
+	 * No getter / setter needed -> read access is in AddressChange repo and update in exporter code
+	 *
+	 * @var \DateTime
+	 *
+	 * @ORM\Column(name="export_date", type="datetime", nullable=true)
+	 */
+	private $exportDate;
 
 	public function __construct( string $addressType ) {
 		$this->addressType = $addressType;


### PR DESCRIPTION
This is for preparing https://phabricator.wikimedia.org/T212870 - Exported address changes need to be marked as exported by setting a date. Entities with no export date aren't exported.