### PR TITLE
Fix timestamp column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Be aware that the concepts of composer as a script runner and containerization m
 
 ## Release notes
 
+### Version 10.3.1 (2019-01-30)
+
+* Fix column names in database for `createdAt` and `modifiedAt` to `AddressChange`
+
 ### Version 10.3.0 (2019-01-29)
 
 * Add `createdAt` and `modifiedAt` to `AddressChange`

--- a/src/Entities/AddressChange.php
+++ b/src/Entities/AddressChange.php
@@ -77,7 +77,7 @@ class AddressChange {
 	 * No getter / setter needed, modification is in AddressChange repo
 	 *
 	 * @var \DateTime
-	 * @ORM\Column(type="datetime")
+	 * @ORM\Column(name="created_at", type="datetime")
 	 */
 	private $createdAt;
 
@@ -87,7 +87,7 @@ class AddressChange {
 	 * No getter / setter needed, modification is in AddressChange repo
 	 *
 	 * @var \DateTime
-	 * @ORM\Column(type="datetime")
+	 * @ORM\Column(name="modified_at", type="datetime")
 	 */
 	private $modifiedAt;
 


### PR DESCRIPTION
Explicitly set the `createdAt` and `modifiedAt` fields of AddressChange
to snake case.