### PR TITLE
Allow additional ORM Mapping Drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Be aware that the concepts of composer as a script runner and containerization m
 
 ## Release notes
 
+### Version 10.5.0 (2020-01-31)
+
+* Add `$additionalMetadataDrivers` parameter to `Factory` to support XML-mapped entities (e.g. in the AddressChange 
+  bounded context).    
+
 ### Version 10.4.1 (2020-01-30)
 
 * Change `donationReceipt` default to `true`


### PR DESCRIPTION
Allow FundraisingFrontend to inject XML annotated classes with
XmlMappingDriver, used in the AddressChange bounded context.

We now have a slightly confusing situation, where we can pass additional
docblock-annotated Entities through the `$doctrineEntityPaths` Factory
constructor parameter and even more XML-annotated entities through the
new `$additionalMetadataDrivers` constructor parameter. See
https://phabricator.wikimedia.org/T232010 for a plan on how the
different mapping drivers and factories will be harmonized and how we get
rid of the central `Factory` class. As a stopgap mesaure, I've added a
docblock to explain the parameters.